### PR TITLE
Helm rego: account for non-namespaced resources

### DIFF
--- a/operations/helm/policies/policies_test.rego
+++ b/operations/helm/policies/policies_test.rego
@@ -27,3 +27,17 @@ test_null_namespace_not_allowed if {
 test_namespace_allowed if {
 	no_violations with input as [{"contents": {"metadata": {"name": "resource", "namespace": "example"}}}]
 }
+
+test_namespace_forbidden_on_psp if {
+	some_violations with input as [{"contents": {
+		"kind": "PodSecurityPolicy",
+		"metadata": {"name": "resource", "namespace": "example"},
+	}}]
+}
+
+test_namespace_forbidden_on_psp if {
+	no_violations with input as [{"contents": {
+		"kind": "PodSecurityPolicy",
+		"metadata": {"name": "resource"},
+	}}]
+}


### PR DESCRIPTION
The rego policies assume that all resources should be namespaced. This is not true for PodSecurityPolicy resources. This PR adds this exception and also verifies that all resources that _shouldn't_ have a namespace actually don't.